### PR TITLE
Add cAdvisor autodiscovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,15 @@ RUN dnf -y install python3-greenlet && dnf clean all && \
     rm -f gevent-1.1.1-cp34-cp34m-linux_x86_64.whl && \
     rm -rf ~/.pip
 
+LABEL io.cadvisor.metric.prometheus-vadvisor="/var/cadvisor/cadvisor_config.json"
+
 RUN \
     curl -LO https://github.com/kubevirt/vAdvisor/archive/$VERSION.tar.gz#/vAdvisor-$VERSION.tar.gz && \
     tar xf vAdvisor-$VERSION.tar.gz && cd vAdvisor-$VERSION && \
     sed -i '/libvirt-python/d' requirements.txt && \
     pip3 --no-cache-dir install -r requirements.txt && pip3 --no-cache-dir install . && \
+    mkdir -p /var/cadvisor && cp cadvisor_config.json /var/cadvisor/ && \
     rm -rf ~/.pip && \
     cd .. && rm -rf vAdvisor-$VERSION*
-    
+
 ENTRYPOINT [ "/usr/bin/vAdvisor" ]

--- a/cadvisor_config.json
+++ b/cadvisor_config.json
@@ -1,0 +1,4 @@
+{
+    "endpoint" : "http://localhost:8181/metrics"
+}
+


### PR DESCRIPTION
Tell cAdvisor where to find our prometheus application metrics by adding
a cadvisor configuration file and specify the file with the right docker
label.
